### PR TITLE
Add npm test pre commit script

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -41,3 +41,10 @@
   exclude: .*
   always_run: true
   entry: lowess/yasha:latest
+
+- id: npm-test
+  name: Run npm tests
+  language: system
+  files: '\.test.(ts|tsx)$'
+  always_run: true
+  entry: npm run test

--- a/README.md
+++ b/README.md
@@ -75,3 +75,15 @@ Example configuration:
     hooks:
       - id: terragrunt-hclfmt
 ```
+### Code Development
+
+#### `npm-test`
+Run [npm-test](https://docs.npmjs.com/cli/v7/commands/npm-test), predefined command specified in the `test` property of a package's `scripts` object.
+
+Example configuration:
+```
+ - hooks:
+      - id: npm-test
+    repo: https://github.com/Lowess/pre-commit-hooks
+    rev: v1.4.0
+```


### PR DESCRIPTION
Added pre-commit hook for running npm tests:

Example usage in config:

```
  - hooks:
      - id: npm-test
    repo: https://github.com/Lowess/pre-commit-hooks
    rev: v1.4.0
```